### PR TITLE
Fix link to 'Getting Started' docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ JanusGraph is a transactional database that can support thousands of concurrent 
 <p>You can <!-- <a href="https://github.com/JanusGraph/janusgraph/releases">download</a> JanusGraph or --> <a href="https://github.com/JanusGraph/janusgraph">clone</a> JanusGraph from GitHub.
 Read the <a href="http://docs.janusgraph.org/0.1.0-SNAPSHOT/">JanusGraph documentation</a> and join the <a href="https://groups.google.com/group/janusgraph-users">users</a> or <a href="https://groups.google.com/group/janusgraph-dev">developers</a> mailing lists</a>.<br />
 
-<p>Follow the <a href="http://docs.jansugraph.org/0.1.0-SNAPSHOT/getting-started.html">Getting Started with JanusGraph</a> guide for a step-by-step introduction.</p>
+<p>Follow the <a href="http://docs.janusgraph.org/0.1.0-SNAPSHOT/getting-started.html">Getting Started with JanusGraph</a> guide for a step-by-step introduction.</p>
 
         <h2>About</h2>
 


### PR DESCRIPTION
The link was broken, simple typo.