### PR TITLE
Convert title from JANUSGRAPH to JanusGraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <h1 id="project_title">JANUSGRAPH</h1>
+          <h1 id="project_title">JanusGraph</h1>
           <h2 id="project_tagline">Distributed Graph Database</h2>
         </header>
     </div>


### PR DESCRIPTION
Not sure how that one snuck through; I kept thinking this was due to CSS somewhere, but turns out, it was hard-coded from the start.