### PR TITLE
Adds a shield for easily seeing the website status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # janusgraph.org
 
+[![Website][website-shield]][website-link]
+
+[website-shield]: https://img.shields.io/website-up-down-green-red/http/janusgraph.org.svg?label=janusgraph.org
+[website-link]: http://janusgraph.org
+
 This repo generates the content served on http://janusgraph.org
 
 To make changes, you should install the local setup and once you're ready to


### PR DESCRIPTION
This badge shows at a glance whether the website is up or down; it could be down
for any number of reasons, e.g., a DNS misconfiguration on the part of the
domain owner or GitHub's hosting, or inability to reach the GitHub servers
hosting the website.

This visual indicator will allow us to more quickly notice the issue and fix it.