### PR TITLE
Add pointers to visualization tools

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,6 +43,13 @@ In addition, JanusGraph provides the following features:
   * [Gremlin graph server](http://tinkerpop.apache.org/docs/3.2.4/reference/#gremlin-server)
   * [Gremlin applications](http://tinkerpop.apache.org/docs/3.2.4/reference/#gremlin-applications)
 * Open source under the [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.html) license.
+* You can visualize graphs stored in JanusGraph via any of the following tools:
+  * [Cytoscape](http://www.cytoscape.org/)
+  * [Gephi](http://tinkerpop.apache.org/docs/current/reference/#gephi-plugin)
+    plugin for Apache TinkerPop
+  * [Graphexp](https://github.com/bricaud/graphexp)
+  * [KeyLines by Cambridge Intelligence](https://cambridge-intelligence.com/visualizing-janusgraph-new-titandb-fork/)
+  * [Linkurious](https://doc.linkurio.us/ogma/latest/tutorials/janusgraph/)
 
 You can [download](https://github.com/JanusGraph/janusgraph/releases) JanusGraph
 or [clone](https://github.com/JanusGraph/janusgraph) from GitHub.


### PR DESCRIPTION
Users frequently want to know how to visualize graphs in JanusGraph, and now
that we have several available integrations, we should make them easy to find in
one place for current and future users.

This change mimics the same change in the GitHub repo's README:
https://github.com/JanusGraph/janusgraph/pull/858

Fixes #29.