### PR TITLE
Hide commands in Makefile, add default target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+VERB = @
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
+
+.PHONY default:
+	$(VERB) echo "Available targets: install, serve"
+
 install:
-	bundle install --path .bundle
+	$(VERB) bundle install --path .bundle
 
 serve:
-	bundle exec jekyll serve
+	$(VERB) bundle exec jekyll serve


### PR DESCRIPTION
Now, running `make` will not automatically take action but instead give you available commands.

`make` will also not echo commands unless run as `make VERBOSE=1`.