### PR TITLE
Add easy Makefile target for pushing to GitHub.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ endif
 .PHONY default:
 	$(VERB) echo "Available targets: install, serve"
 
+# Pushes the current branch, provided via $(git rev-parse ...) to the `gh-pages`
+# branch on your repo. Assumes this branch is set to display a preview via
+# GitHub pages, as recommended in the instructions on the git repo:
+# https://github.com/janusgraph/janusgraph.org/#preview-via-github
+preview-via-github:
+	git push -f origin $$(git rev-parse --abbrev-ref HEAD):gh-pages
+
 install:
 	$(VERB) bundle install --path .bundle
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ fork as follows:
    selected above; this branch must exist at the time of running the above
    command.
 
+   To simplify this process, you can also run:
+
+   ```
+   $ make preview-via-github
+   ```
+
+   which actually runs the following command:
+
+   ```
+   $ git push -f origin $$(git rev-parse --abbrev-ref HEAD):gh-pages
+
+   ```
+
+   which automatically discovers the current branch you're on and pushes that
+   to GitHub, using the `gh-pages` branch.
+
 1. Visit the "Settings" page for your fork on GitHub and make the `gh-pages`
    auto-publishable
    * note: after you make this change, you will get an email that you could not


### PR DESCRIPTION
Add a target that pushes current branch to `gh-pages` branch on one's
GitHub fork by computing the current branch name using git.