### PR TITLE
Use HTTPS for all JanusGraph domains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Website][website-shield]][website-link]
 
 [website-shield]: https://img.shields.io/website-up-down-green-red/http/janusgraph.org.svg?label=janusgraph.org
-[website-link]: http://janusgraph.org
+[website-link]: https://janusgraph.org
 
-This repo generates the content served on http://janusgraph.org
+This repo generates the content served on https://janusgraph.org
 
 To make changes, you should install the local setup and once you're ready to
 submit changes, please provide a pointer to a previewable version via your
@@ -45,7 +45,7 @@ fork as follows:
 1. [Fork the website repo](https://github.com/JanusGraph/janusgraph.org#fork-destination-box)
    to your account via GitHub
    * note: the `master` branch of this repo is the one that is auto-published to
-     http://janusgraph.org soon after a commit
+     https://janusgraph.org soon after a commit
 
 1. Clone your copy of the repo locally
 
@@ -120,7 +120,7 @@ fork as follows:
      are trying to create a personal test copy, not update the live site.
 
 1. Now you can visit your site at
-   `http://[your-username].github.io/janusgraph.org/` to see your changes
+   `https://[your-username].github.io/janusgraph.org/` to see your changes
 
 1. Now you can push your `[MY-BRANCH-NAME]` to your fork to open a pull request
    using it.

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: "JanusGraph: Distributed graph database"
 ---
 
 <center>
-  <a href="http://docs.janusgraph.org/latest/">Docs</a> &bull;
+  <a href="https://docs.janusgraph.org/latest/">Docs</a> &bull;
   <a href="https://github.com/JanusGraph/janusgraph/">GitHub</a> &bull;
   <a href="https://github.com/JanusGraph/janusgraph/releases/">Download</a><br />
   <img class="janusgraph" src="images/janusgraph.png" />
@@ -54,11 +54,11 @@ In addition, JanusGraph provides the following features:
 You can [download](https://github.com/JanusGraph/janusgraph/releases) JanusGraph
 or [clone](https://github.com/JanusGraph/janusgraph) from GitHub.
 
-Read the [JanusGraph documentation](http://docs.janusgraph.org/latest) and join the
+Read the [JanusGraph documentation](https://docs.janusgraph.org/latest) and join the
 [users](https://groups.google.com/group/janusgraph-users) or
 [developers](https://groups.google.com/group/janusgraph-dev) mailing lists.
 
-Follow the [Getting Started with JanusGraph](http://docs.janusgraph.org/latest/getting-started.html) guide for a step-by-step introduction.
+Follow the [Getting Started with JanusGraph](https://docs.janusgraph.org/latest/getting-started.html) guide for a step-by-step introduction.
 
 ## <a name="about"></a>About
 


### PR DESCRIPTION
Now that issue #58 is fixed, we can use HTTPS for janusgraph.org,
while docs.janusgraph.org has already supported it for a long time.