### PR TITLE
Use HTTPS in the website up/down checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Website][website-shield]][website-link]
 
-[website-shield]: https://img.shields.io/website-up-down-green-red/http/janusgraph.org.svg?label=janusgraph.org
+[website-shield]: https://img.shields.io/website-up-down-green-red/https/janusgraph.org.svg?label=janusgraph.org
 [website-link]: https://janusgraph.org
 
 This repo generates the content served on https://janusgraph.org


### PR DESCRIPTION
This was missed in the last round of updates in PR #59.