### PR TITLE
Add Aerospike storage adapter

### DIFF
--- a/_includes/features.html
+++ b/_includes/features.html
@@ -82,8 +82,9 @@
                 <div>
                     <p class="feature-text">There are different 3rd party storage adapters for JanusGraph:</p>
                     <ul class="central-list">
-                        <li><a class="feature-link" href="https://github.com/experoinc/janusgraph-foundationdb">FoundationDB</a></li>
+                        <li><a class="feature-link" href="https://github.com/Playtika/aerospike-janusgraph-storage-backend">Aerospike</a></li>
                         <li><a class="feature-link" href="https://github.com/awslabs/dynamodb-janusgraph-storage-backend">DynamoDB</a></li>
+                        <li><a class="feature-link" href="https://github.com/experoinc/janusgraph-foundationdb">FoundationDB</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Add Aerospike storage adapter.
Sort adapters in lexicographic order.

DEMO Preview: https://porunov.github.io/janusgraph.org

Signed-off-by: Oleksandr Porunov <alexandr.porunov@gmail.com>