### PR TITLE
Replace Gitter with Discord link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,8 +69,8 @@ color:
 social:
   - icon: fab fa-twitter
     url: https://twitter.com/JanusGraph
-  - icon: fab fa-gitter
-    url: https://gitter.im/janusgraph/janusgraph
+  - icon: fab fa-discord
+    url: https://discord.gg/5n4fjv4QAf
   - icon: fab fa-stack-overflow
     url: https://stackoverflow.com/questions/tagged/janusgraph
   - icon: fab fa-github


### PR DESCRIPTION
Discord is now our main chat platform so we want new users to directly go there instead of Gitter.

Fixes #96

Preview is available here: https://florianhockmann.github.io/janusgraph.org/